### PR TITLE
Reduce fade time of flip-to-hack hover sounds

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -180,11 +180,15 @@
     },
     "shell/tracking-button/flip/hover": {
         "sound-file": "Hover_Flip.wav",
-        "loop": true
+        "loop": true,
+        "fade-in": 100,
+        "fade-out": 100
     },
     "shell/tracking-button/flip-inverse/hover": {
         "sound-file": "Hover_InverseFlip.wav",
-        "loop": true
+        "loop": true,
+        "fade-in": 100,
+        "fade-out": 100
     },
     "shell/tracking-button/flip/click": {
         "sound-file": "MouseClick_Flip.wav"


### PR DESCRIPTION
These have to fade in and out quickly, or else several of them will keep
playing for one second long if you hover in and out of the flip-to-hack
button quickly.

https://phabricator.endlessm.com/T24523