### PR TITLE
server: Send EOS event if no fade-out time

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -64,6 +64,7 @@ class HackSoundPlayer(GObject.Object):
 
         if pipeline_fade_out == 0:
             self._stop_loop = True
+            self.pipeline.send_event(Gst.Event.new_eos())
             return
 
         volume_elem = self.pipeline.get_by_name('volume')


### PR DESCRIPTION
Before this commit, the last loop of the sound kept playing
before it was actually stopped. This commit sends an EOS event
to force the stop of a looping sound without fade out time.

https://phabricator.endlessm.com/T24787