### PR TITLE
metadata: Use multiple sounds

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1,5 +1,6 @@
 import gi
 import logging
+import random
 import uuid
 gi.require_version('GLib', '2.0')  # noqa
 gi.require_version('Gst', '1.0')   # noqa
@@ -168,7 +169,7 @@ class HackSoundPlayer(GObject.Object):
 
     @property
     def sound_location(self):
-        return self.metadata["sound-file"]
+        return random.choice(self.metadata["sound-files"])
 
     def _add_keyframe_pair(self, control, time_start_ns, value_start,
                            time_end_ns, value_end, consider_duration=True):

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -9,10 +9,16 @@ _logger = logging.getLogger(__name__)
 
 
 def _read_in_metadata(metadata, user_type):
+    sounds_dir = get_sounds_dir(user_type)
     for sound_event_id in metadata:
-        metadata[sound_event_id]["sound-file"] =\
-            os.path.join(get_sounds_dir(user_type),
-                         metadata[sound_event_id]["sound-file"])
+        sound_files = metadata[sound_event_id].get("sound-files", [])
+        # If both "sound-file" and "sound-files" are specified, we consider all
+        # the available sounds.
+        if "sound-file" in metadata[sound_event_id]:
+            sound_files.append(metadata[sound_event_id]["sound-file"])
+
+        metadata[sound_event_id]["sound-files"] =\
+            [os.path.join(sounds_dir, path) for path in set(sound_files)]
 
 
 def load_metadata(user_type):


### PR DESCRIPTION
Now, an entry in the metadata can be something like this.

    "sound-files": [
        "sound1.wav",
        "sound2.wav"
    ]

If a list of sounds in "sound-files" the server will pick one
randomly. If only a sound "sound-file" is given it will be
converted to a "sound-files" list of an only one item. If both
"sound-file" and "sound-files" are given, their values will be
merged into "sound-files".

https://phabricator.endlessm.com/T24849