### PR TITLE
metadata: Error in metadata should not be fatal

### DIFF
--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -33,7 +33,7 @@ def load_metadata(user_type):
                 metadata = json.load(metadata_file)
                 _read_in_metadata(metadata, user_type)
                 ret = metadata
-            except json.decoder.JSONDecodeError as e:
+            except Exception as e:
                 _logger.error(
                     "Not possible to decode metadata file at '%s'.\n"
                     "%s" % (metadata_path, e))


### PR DESCRIPTION
In the case where the user metadata is wrong, we can just fall back to
the system metadata. In the case where the system metadata is wrong, we
can't really play any sounds, but the existing behaviour was already to
ignore JSON decode errors but crash on metadata validation errors; this
makes it consistent instead.

https://phabricator.endlessm.com/T24944