### PR TITLE
server: Allow to unset values before setting a keyframe pair

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -186,6 +186,7 @@ class HackSoundPlayer(GObject.Object):
 
     def _add_keyframe_pair(self, control, time_start_ns, value_start,
                            time_end_ns, value_end, consider_duration=True):
+        control.unset_all()
         if not self._add_keyframe(control, time_start_ns, value_start):
             raise ValueError('bad start time')
         # Rather than deal with the case where we have to split the keyframes


### PR DESCRIPTION
This would solve the problems described in
Scenarios 1, 2 and 3 described in the following task:

https://phabricator.endlessm.com/T25046