### PR TITLE
player: Avoid playing sounds if they are about to stop

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -81,6 +81,8 @@ class HackSoundPlayer(GObject.Object):
             self._add_fade_out(volume_elem, self.fade_out)
 
     def _play(self, fades_in):
+        if self._stop_loop:
+            return
         self.pipeline.set_state(Gst.State.PLAYING)
         if fades_in:
             self._add_fade_in(self.fade_in, self.volume)


### PR DESCRIPTION
This is workaround for the following problem: currently when a
sound instance (uuid) receives a StopSound request and its
Refcount has reached 0, the Player is requested to stop the sound
(just a call to the 'Player.stop' method). But we do not release
server structures until the Player for this UUID notifies with the
'release' signal... and in the case of looping sounds this signal
is emitted just when the fade-out effect finishes.

The ideal solution would be to clear server structs/tables like
'HackSoundServer.players' and other similar entries that may be
referring the sound just as soon the 'Player.stop' method was
called... So if a request comes while the sound is stopping fading
out, the UUID wouldn't be found in the tables and a WARNING would
be shown because the UUID does not exist.

https://phabricator.endlessm.com/T25385