### PR TITLE
metadata: Merge system and user metadata

### DIFF
--- a/com.endlessm.HackSoundServer.json.in
+++ b/com.endlessm.HackSoundServer.json.in
@@ -75,6 +75,34 @@
             ]
         },
         {
+            "name": "python3-vcver",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} vcver"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fd/5d/c8c80d1a6c4f0bed4cd52747294ba95219bb79587da27d34d9e428b5849c/vcver-0.1.1.tar.gz",
+                    "sha256": "e4c1eff7af4123cca80597367cb5d41dd57cd9711de0d5804d7b3935cc04f1a0"
+                }
+            ]
+        },
+        {
+            "name": "python3-deepmerge",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} deepmerge"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a9/14/7bd117a34ed4199664ad28367814ebac54012c5f6176ed333667d7d469b6/deepmerge-0.0.5.tar.gz",
+                    "sha256": "d8c5c309340a51e0d7a84adb020d459dc79794d789ea03a56e954ac115089fa5"
+                }
+            ]
+        },
+        {
             "name": "hack-sound-server",
             "buildsystem": "meson",
             "config-opts" : [

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -3,6 +3,7 @@ import os
 from hack_sound_server.utils.misc import get_metadata_path
 from hack_sound_server.utils.misc import get_sounds_dir
 from hack_sound_server.utils.loggable import logger
+from deepmerge import always_merger
 
 
 def _read_in_metadata(metadata, user_type):
@@ -51,6 +52,5 @@ def read_and_parse_metadata():
         return user_metadata
     if user_metadata is None:
         return system_metadata
-    metadata = system_metadata
-    metadata.update(user_metadata)
+    metadata = always_merger.merge(system_metadata, user_metadata)
     return metadata


### PR DESCRIPTION
If the system metadata is specified as for example:

    ```
    "foo/foo": {
        "sound-file": "foo.wav",
        "volume": 0.4,
        "loop": true
    }
    ```
but the user metadata specified as

    "foo/foo": {
        "volume": 0.8
    }

then "foo/foo" will be a looping sound played back with a volume of
0.8 instead of 0.4

https://phabricator.endlessm.com/T25632