### PR TITLE
Make "active lockscreen" sound into background music

### DIFF
--- a/data/metadata.json
+++ b/data/metadata.json
@@ -497,6 +497,7 @@
     "hack-toolbox/lockscreen/active": {
         "sound-file": "toolbox/lockscreenActive.webm",
         "loop": true,
+        "bg": true,
         "overlap-behavior": "ignore"
     },
     "hack-toolbox/lockscreen/inactive": {


### PR DESCRIPTION
This loop is often playing over so many other background music tracks,
it does not seem like it should be foregrounded.

Hopefully this helps with the problem of too many sounds being played at
the same time. I suspect this is a major offender.

https://phabricator.endlessm.com/T25696