### PR TITLE
flatpak: Disable libaom in gst-plugin-bad

### DIFF
--- a/com.endlessm.HackSoundServer.json.in
+++ b/com.endlessm.HackSoundServer.json.in
@@ -29,6 +29,7 @@
         {
             "name": "gstreamer-plugin-soundtouch",
             "config-opts": [
+                "--disable-aom",
                 "--disable-nls",
                 "--disable-introspection",
                 "--disable-gtk-doc",


### PR DESCRIPTION
The last update of the org.gnome.Sdk//3.30 breaks the gst-plugins-bad
compilation because of the libaom so we need to disable it to be able to
build meantime this issue is fixed in the Sdk.

https://phabricator.endlessm.com/T25736