### PR TITLE
Add appdata

### DIFF
--- a/com.endlessm.HackSoundServer.appdata.xml
+++ b/com.endlessm.HackSoundServer.appdata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.endlessm.HackSoundServer.desktop</id>
+  <name>Hack Sound Server</name>
+  <summary>D-Bus-based server for playing sounds</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+</component>

--- a/meson.build
+++ b/meson.build
@@ -60,12 +60,20 @@ install_subdir(
     strip_directory: true
 )
 
+data_dir = join_paths(get_option('prefix'), get_option('datadir'))
+
+install_data(
+    'com.endlessm.HackSoundServer.appdata.xml',
+    install_dir: join_paths(data_dir, 'appdata')
+)
+
 message('\n'.join([
     '@0@ @1@'.format(meson.project_name(), meson.project_version()),
     '--------------------------------------',
     'Directories:',
     '    prefix: @0@'.format(get_option('prefix')),
     '    bindir: @0@'.format(get_option('bindir')),
+    '    datadir: @0@'.format(data_dir),
     '    session_bus_services_dir: @0@'.format(session_bus_services_dir),
     ''
 ]))


### PR DESCRIPTION
GNOME Software relies heavily on the AppStream/appdata for managing
apps, so we make sure that the HackSoundServer has the appdata.

https://phabricator.endlessm.com/T26020