### PR TITLE
utils: Remove external dependencies and change behavior of user metadata

### DIFF
--- a/com.hack_computer.HackSoundServer.json.in
+++ b/com.hack_computer.HackSoundServer.json.in
@@ -78,34 +78,6 @@
             ]
         },
         {
-            "name": "python3-vcver",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} vcver"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/fd/5d/c8c80d1a6c4f0bed4cd52747294ba95219bb79587da27d34d9e428b5849c/vcver-0.1.1.tar.gz",
-                    "sha256": "e4c1eff7af4123cca80597367cb5d41dd57cd9711de0d5804d7b3935cc04f1a0"
-                }
-            ]
-        },
-        {
-            "name": "python3-deepmerge",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} deepmerge"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a9/14/7bd117a34ed4199664ad28367814ebac54012c5f6176ed333667d7d469b6/deepmerge-0.0.5.tar.gz",
-                    "sha256": "d8c5c309340a51e0d7a84adb020d459dc79794d789ea03a56e954ac115089fa5"
-                }
-            ]
-        },
-        {
             "name": "hack-sound-server",
             "buildsystem": "meson",
             "config-opts" : [

--- a/src/utils/metadata.py
+++ b/src/utils/metadata.py
@@ -3,7 +3,6 @@ import os
 from hack_sound_server.utils.misc import get_metadata_path
 from hack_sound_server.utils.misc import get_sounds_dir
 from hack_sound_server.utils.loggable import logger
-from deepmerge import always_merger
 
 
 def _read_in_metadata(metadata, user_type):
@@ -21,7 +20,7 @@ def _read_in_metadata(metadata, user_type):
 
 def load_metadata(user_type):
     metadata_path = get_metadata_path(user_type)
-    ret = None
+    ret = {}
 
     if os.path.exists(metadata_path):
         with open(metadata_path, "r") as metadata_file:
@@ -47,10 +46,5 @@ def load_metadata(user_type):
 def read_and_parse_metadata():
     system_metadata = load_metadata("system")
     user_metadata = load_metadata("user")
-
-    if system_metadata is None:
-        return user_metadata
-    if user_metadata is None:
-        return system_metadata
-    metadata = always_merger.merge(system_metadata, user_metadata)
-    return metadata
+    system_metadata.update(user_metadata)
+    return system_metadata


### PR DESCRIPTION
User metadata now updates the whole keys, instead of doing a deep
merge. The deep merge behavior is removed for simplicity, and to avoid
relying on external dependencies.

https://phabricator.endlessm.com/T29018